### PR TITLE
Add some basic licenses

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -150,7 +150,7 @@ checksum = "7fe5bd57d1d7414c6b5ed48563a2c855d995ff777729dcd91c369ec7fea395ae"
 
 [[package]]
 name = "spdx-blaster"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "clap",
  "env_logger",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "spdx-blaster"
-version = "0.1.0"
+version = "0.1.1"
 authors = ["terkwood <38859656+Terkwood@users.noreply.github.com>"]
 edition = "2018"
 

--- a/README.md
+++ b/README.md
@@ -33,6 +33,24 @@ extern crate log;
 extern crate memmap;
 ```
 
+### Specify a License
+
+`spdx-blaster` doesn't know about very many licenses yet, but it
+can handle some of the most popular ones.  Use the `--license` argument (or `-l`) to specify which license you want to use.
+
+```sh
+spdx-blaster -l gpl-3.0-or-later test.kt
+spdx-blaster --license gpl-2.0-only test.java
+```
+
+You may omit several types of punctuation from the
+license ID specification, but you must include
+all the alphanumeric characters used in the license ID.
+
+```sh
+spdx-blaster -l apache20 test.cs
+```
+
 ## ⚠️ Warning!
 
 We can't guarantee a crash-free experience in the case where another process is editing your source code at the same time as `spdx-blaster`. 

--- a/src/ids.rs
+++ b/src/ids.rs
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: MIT
 pub const ID_APACHE20: &str = "Apache-2.0";
 pub const ID_MIT: &str = "MIT";
 pub const ID_GPL_20_ONLY: &str = "GPL-2.0-only";

--- a/src/ids.rs
+++ b/src/ids.rs
@@ -1,0 +1,4 @@
+pub const ID_APACHE20: &str = "Apache-2.0";
+pub const ID_MIT: &str = "MIT";
+pub const ID_GPL_20_ONLY: &str = "GPL-2.0-only";
+pub const ID_GPL_30_OR_LATER: &str = "GPL-3.0-or-later";

--- a/src/license.rs
+++ b/src/license.rs
@@ -3,7 +3,10 @@ use std::fmt;
 
 #[derive(Copy, Clone, Debug)]
 pub enum License {
+    Apache20,
     MIT,
+    GPL20Only,
+    GPL30OrLater,
 }
 
 const PREFIX: &str = "SPDX-License-Identifier: ";
@@ -14,12 +17,29 @@ impl License {
     }
 }
 
-/// See https://spdx.dev/ids/
+/// This implementation of Display must conform exactly
+/// to SPDX license strings.
+///
+/// It uses https://spdx.org/licenses/ as the source of
+/// truth for these strings.
 impl fmt::Display for License {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let s = match self {
+            License::Apache20 => "Apache-2.0",
             License::MIT => "MIT",
+            License::GPL20Only => "GPL-2.0-only",
+            License::GPL30OrLater => "GPL-3.0-or-later",
         };
         write!(f, "{}{}", PREFIX, s)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn trivial() {
+        assert_eq!(License::MIT.to_string(), "SPDX-License-Identifier: MIT");
     }
 }

--- a/src/license.rs
+++ b/src/license.rs
@@ -1,7 +1,9 @@
 // SPDX-License-Identifier: MIT
 use std::fmt;
 
-#[derive(Copy, Clone, Debug)]
+use crate::ids::*;
+
+#[derive(Copy, Clone, Debug, PartialEq)]
 pub enum License {
     Apache20,
     MIT,
@@ -11,9 +13,35 @@ pub enum License {
 
 const PREFIX: &str = "SPDX-License-Identifier: ";
 
-impl License {
-    pub fn from(_s: &str) -> Self {
+impl Default for License {
+    fn default() -> Self {
         License::MIT
+    }
+}
+
+impl License {
+    pub fn from(s: &str) -> Self {
+        match s.trim().to_lowercase() {
+            t if License::Apache20.compare_lc(&t) => License::Apache20,
+            t if License::GPL20Only.compare_lc(&t) => License::GPL20Only,
+            t if License::GPL30OrLater.compare_lc(&t) => License::GPL30OrLater,
+            t if License::MIT.compare_lc(&t) => License::MIT,
+            _ => License::default(),
+        }
+    }
+
+    pub fn id(self) -> String {
+        match self {
+            License::Apache20 => ID_APACHE20,
+            License::GPL20Only => ID_GPL_20_ONLY,
+            License::GPL30OrLater => ID_GPL_30_OR_LATER,
+            License::MIT => ID_MIT,
+        }
+        .to_string()
+    }
+
+    fn compare_lc(self, t: &str) -> bool {
+        t == self.id().trim().to_lowercase()
     }
 }
 
@@ -24,13 +52,7 @@ impl License {
 /// truth for these strings.
 impl fmt::Display for License {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        let s = match self {
-            License::Apache20 => "Apache-2.0",
-            License::MIT => "MIT",
-            License::GPL20Only => "GPL-2.0-only",
-            License::GPL30OrLater => "GPL-3.0-or-later",
-        };
-        write!(f, "{}{}", PREFIX, s)
+        write!(f, "{}{}", PREFIX, self.id())
     }
 }
 
@@ -39,7 +61,13 @@ mod tests {
     use super::*;
 
     #[test]
-    fn trivial() {
+    fn display() {
         assert_eq!(License::MIT.to_string(), "SPDX-License-Identifier: MIT");
+    }
+
+    #[test]
+    fn from() {
+        assert_eq!(License::from("MIT"), License::MIT);
+        assert_eq!(License::from("GPL-3.0-or-later"), License::GPL30OrLater);
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -20,6 +20,8 @@ use crate::license::License;
 const NAME: &str = env!("CARGO_PKG_NAME");
 const VERSION: &str = env!("CARGO_PKG_VERSION");
 
+/// Writes [SPDX license IDs](https://spdx.dev/ids/) into your source
+/// files.
 fn main() {
     env_logger::init();
     trace!("🔢 {}", VERSION);

--- a/src/main.rs
+++ b/src/main.rs
@@ -8,6 +8,7 @@ pub mod blaster;
 mod comment;
 mod dialect;
 mod files;
+mod ids;
 mod license;
 
 use clap::{App, Arg};
@@ -25,6 +26,7 @@ const VERSION: &str = env!("CARGO_PKG_VERSION");
 fn main() {
     env_logger::init();
     trace!("🔢 {}", VERSION);
+    let default_license_id = License::MIT.id();
     let args = App::new(NAME)
         .version(VERSION)
         .author("terkwood <38859656+Terkwood@users.noreply.github.com>")
@@ -33,9 +35,9 @@ fn main() {
             Arg::with_name("license")
                 .short("l")
                 .long("license")
-                .help("Specify which license you wish to apply")
+                .help("Specify which license you wish to apply. Use the official SPDX license ID, e.g.  GPL-2.0-or-later")
                 .takes_value(true)
-                .default_value("MIT"),
+                .default_value(&default_license_id),
         )
         .arg(
             Arg::with_name("display")


### PR DESCRIPTION
Advances #2 and #6.   Allows some flexibility in the specification of the license identifier.